### PR TITLE
[Feature] Automatic start of dead services when worker services are restarted. #218

### DIFF
--- a/datasophon-api/src/main/java/com/datasophon/api/controller/ClusterServiceCommandController.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/controller/ClusterServiceCommandController.java
@@ -75,15 +75,11 @@ public class ClusterServiceCommandController {
     @RequestMapping("/generateServiceCommand")
     @UserPermission
     public Result generateServiceCommand(Integer clusterId, String commandType, String serviceInstanceIds) {
-        CommandType command = EnumUtil.fromString(CommandType.class, commandType);
-        if(StringUtils.isNotBlank(serviceInstanceIds)){
-            List<String> ids = Arrays.asList(serviceInstanceIds.split(","));
-            return clusterServiceCommandService.generateServiceCommand(clusterId, command, ids);
-        }else {
+        if (StringUtils.isBlank(serviceInstanceIds)) {
             return Result.error(Status.NO_SERVICE_EXECUTE.getMsg());
         }
 
-
+        return clusterServiceCommandService.generateServiceCommand(clusterId, commandType, serviceInstanceIds);
     }
 
     /**
@@ -104,7 +100,7 @@ public class ClusterServiceCommandController {
     @RequestMapping("/startExecuteCommand")
     @UserPermission
     public Result startExecuteCommand(Integer clusterId, String commandType, String commandIds) {
-        clusterServiceCommandService.startExecuteCommand(clusterId,commandType,commandIds);
+        clusterServiceCommandService.startExecuteCommand(clusterId, commandType, commandIds);
         return Result.success();
     }
 
@@ -113,7 +109,6 @@ public class ClusterServiceCommandController {
         clusterServiceCommandService.cancelCommand(commandId);
         return Result.success();
     }
-
 
 
     /**

--- a/datasophon-api/src/main/java/com/datasophon/api/service/ClusterServiceCommandService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/ClusterServiceCommandService.java
@@ -39,7 +39,7 @@ public interface ClusterServiceCommandService extends IService<ClusterServiceCom
 
     Result getServiceCommandlist(Integer clusterId, Integer page, Integer pageSize);
 
-    Result generateServiceCommand(Integer clusterId, CommandType command, List<String> ids);
+    Result generateServiceCommand(Integer clusterId, String commandType, String serviceInstanceIds);
 
     Result generateServiceRoleCommand(Integer clusterId, CommandType command, Integer serviceIntanceId, List<String> ids);
 

--- a/datasophon-api/src/main/java/com/datasophon/api/service/ClusterServiceRoleInstanceService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/ClusterServiceRoleInstanceService.java
@@ -69,5 +69,8 @@ public interface ClusterServiceRoleInstanceService extends IService<ClusterServi
     List<ClusterServiceRoleInstanceEntity> listServiceRoleByName(String alertManager);
 
     ClusterServiceRoleInstanceEntity getServiceRoleInsByHostAndName(String hostName, String serviceRoleName);
+
+    List<ClusterServiceRoleInstanceEntity> getStoppedService(Integer clusterId);
+
 }
 

--- a/datasophon-api/src/main/java/com/datasophon/api/service/impl/ClusterServiceRoleInstanceServiceImpl.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/impl/ClusterServiceRoleInstanceServiceImpl.java
@@ -314,4 +314,13 @@ public class ClusterServiceRoleInstanceServiceImpl extends ServiceImpl<ClusterSe
                 .eq(Constants.HOSTNAME, hostName)
                 .eq(Constants.SERVICE_ROLE_NAME, serviceRoleName));
     }
+
+    @Override
+    public List<ClusterServiceRoleInstanceEntity> getStoppedService(Integer clusterId) {
+        return roleInstanceService.lambdaQuery()
+                .eq(ClusterServiceRoleInstanceEntity::getClusterId, clusterId)
+                .eq(ClusterServiceRoleInstanceEntity::getServiceRoleState, ServiceRoleState.STOP)
+                .list();
+    }
+
 }


### PR DESCRIPTION
## Purpose of the pull request

Automatic start of dead services when worker services are restarted.

## Brief change log

1. Business process of layer ClusterServiceCommandController.generateServiceCommand() is sunk to ClusterServiceCommandServiceImpl.
2. Add a query way, which used to query all stopped service of target cluster, in class ClusterServiceRoleInstanceServiceImpl.
3. Add auto-start of dead services in class WorkerStartActor.

## Verify this pull request

This pull request is code cleanup without any test coverage.
